### PR TITLE
Add Tower validation and improve docs and sample_vars for ansible-tower advanced

### DIFF
--- a/ansible/configs/ansible-tower-advanced/README.adoc
+++ b/ansible/configs/ansible-tower-advanced/README.adoc
@@ -1,74 +1,45 @@
-= ansible-tower config
+= ansible-tower-advanced lab config
 
-Author: Prakhar Srivastava, psrivast@redhat.com and Shachar Boresntein, sha@redhat.com
-Owner: Prakhar Srivastava, psrivast@redhat.com
-Alternative Contacts: Tony Kay, tok@redhat.com,
+Author: Eric Lavarde <elavarde@redhat.com>
+Owner: Eric Lavarde <elavarde@redhat.com>
+Alternative Contacts: Goetz Rieger <grieger@redhat.com>
 
 == Overview
 
-ansible-tower config was initially created for the babylon Project to deploy Ansible Tower and worker ndoes (isolated nodes)
+This config was create from the ansible-tower config and extended to cover the
+Ansible Tower Advanced Lab.
 
+== Setup
 
-+
-[source,yaml]
-----
-deploy_tower_homework: true
-----
-
-== NOTES
-
-. There are 2 sets of deployer scripts:
-**
-**
-. There are 2 sets of secrets files:
-**
-**
-
-The "homework" lab requires additional secrets over and above the usual cloud (AWS)
-credentails and repo path. These are traditionally stored on the admin host and
-can be located via the relevant deployer scripts.
-
-
-== Review the Env_Type variable file
-
-* This file link:./env_vars.yml[./env_vars.yml] contains all the variables you
- need to define to control, or customize, the deployment of your environment. In
-normal usage this should not need to be touched or ammended and one-off changes
-can be tested by passing vars or var files with `-e` or `-e @my_version_vars.yml`.
-
-
-== Secrets
-
-As noted above a deploy of the normal lab requires just 3
+Copy the `sample_vars.yml` to a place outside of the Git repo (for security reasons)
+and adapt the variables to your needs. You can also add and overwrite variables
+present in the link:env_vars.yml[env_vars.yml file].
 
 == Running Ansible Playbook
 
+From the `agnosticd/ansible` directory run:
 
-
-You can run the playbook with the following arguments to overwrite the default variable values:
-From the `ansible_agnostic_deployer/ansible` directory run
-`
 [source,bash]
 ----
-ansible-playbook ansible/main.yml  \
-      -e @./ansible/configs/ans-tower-prod/sample_vars.yml \
-      -e @../secret.yml \
-      -e "guid=sborenstest2" -vvvv
+ansible-playbook main.yml  \
+      -e @.../my_adapted_sample_vars_with_my_secrets.yml \
 ----
+
+TIP: you can repeat certain steps of the deployment by using tags, just make
+     sure that the tags `must` and `create_inventory` are included, e.g.
+     to only validate the Tower installation after it has been setup:
+     `ansible-playbook ansible/main.yml --tags must,create_inventory,tower_validate -e ...`.
 
 === To Delete an environment
+
+From the `agnosticd/ansible` directory run:
+
+[source,bash]
+----
+ansible-playbook destroy.yml  \
+      -e @.../my_adapted_sample_vars_with_my_secrets.yml \
 ----
 
-REGION=us-east-1
-KEYNAME=ocpkey
-GUID=test02
-ENVTYPE=ans-tower-lab
-CLOUDPROVIDER=ec2
-
-ansible-playbook configs/${ENVTYPE}/destroy_env.yml \
-        -e "guid=${GUID}" -e "env_type=${ENVTYPE}" \
-        -e "cloud_provider=${CLOUDPROVIDER}" \
-        -e "aws_region=${REGION}"  -e "key_name=${KEYNAME}"  \
-        -e "subdomain_base_suffix=${BASESUFFIX}" \
-        -e @~/secret.yml -vv
-----
+CAUTION: it is recommended to destroy the environment if the deployment fails during the
+         infrastructure deployment, as it might not properly recover. A failure during
+         the software deployment can generally be recovered without destroy.

--- a/ansible/configs/ansible-tower-advanced/post_software.yml
+++ b/ansible/configs/ansible-tower-advanced/post_software.yml
@@ -22,12 +22,14 @@
 
 
 - name: PostSoftware flight-check
-  hosts: localhost
-  connection: local
+  hosts: bastions
   gather_facts: false
   become: false
   tags:
-    - post_flight_check
+  - post_flight_check
   tasks:
-    - debug:
-        msg: "Post-Software checks completed successfully"
+  - name: validate the Tower setup
+    import_role:
+      name: tower_validate
+    tags:
+    - tower_validate

--- a/ansible/configs/ansible-tower-advanced/sample_vars.yml
+++ b/ansible/configs/ansible-tower-advanced/sample_vars.yml
@@ -2,35 +2,40 @@
 cloudformation_retries: 0
 
 # ## Environment size
-tower_instance_count: 1
-support_instance_count: 1
-tower_instance_type: "t2.medium"
-support_instance_type: "t2.medium"
+#tower_instance_count: 3
+#support_instance_count: 5 # 1 DB, 2 normal nodes, 2 isolated nodes
+#tower_instance_type: "t2.medium"
+#support_instance_type: "t2.medium"
 root_filesystem_size: 20                #Size of the root filesystem
 
 # Env config basics
-env_type: ansible-tower                 # Name of config to deploy
-output_dir: /opt/workdir               # Writable working scratch directory
-email: name@example.com                 # User info for notifications
-
-#guid: hwtest2                          # Unique string used in FQDN
+env_type: ansible-tower-advanced                 # Name of config to deploy
+output_dir: /var/tmp/ans_tower_adv_workdir     # Writable working scratch directory
+email: jsmith@example.com                 # User info for notifications
 
 # AWS specific
-subdomain_base_suffix: .example.opentlc.com      # Your domain used in FQDN
+guid: whateverunique
+subdomain_base_suffix: .example.com      # Your domain used in FQDN
 
 # Path to yum repos (Will be overwritten by the last -e@ file, such as ../secrets.yml)
-own_repo_path: http://admin.example.com/repos/product
+own_repo_path: "http://www.example.com/repos/{{ software_to_deploy }}"
 
 # Cloud specfic settings - example given here for AWS
 
 cloud_provider: ec2                     # Which AgnosticD Cloud Provider to use
-aws_region: ap-southeast-2
-HostedZoneId: Z3IHLWJZOU9SRT            # You will need to change this
-key_name: ocpkey                       # Keyname must exist in AWS
+aws_region: us-west-1
+HostedZoneId: XXXXXXXXXXXXXX            # You will need to change this
+key_name: id_rsa_xxx                    # Keyname must exist in AWS
+
+aws_access_key_id: ABCDEFGHIJKLMN123456
+aws_secret_access_key: RTzkljHD2ourLJLls/lasjf/alsjf0a/LKDJL40X
+
+key_local_path:
+    - "~/.ssh/{{key_name}}.pem"
 
 #Ansible Tower related vars
 
-tower_version: 3.5.0-1                 # tower version you want to install
+#tower_version: 3.6.0-1                 # tower version you want to install
 software_to_deploy: tower              # Define tower to install tower or none to have only infra ready.
 
 
@@ -38,12 +43,12 @@ software_to_deploy: tower              # Define tower to install tower or none t
 
 
 #### Worker Node for Isolated Node group
-# worker_instance_type: "t2.medium"
-worker_instance_count: 0              # Set 0 to not to provision worker(isolated) nodes.
+#worker_instance_type: "t2.medium"
+#worker_instance_count: 1              # Set 0 to not to provision worker(isolated) nodes.
 
 ## target_region for worker regions
-# target_regions:
-#  - name: emea
+target_regions:
+  - name: emea
 #  - name: apac
 
 default_workloads:
@@ -86,21 +91,20 @@ tower_inventories:
 
 
 
-# tower_license: >                     #Set the tower licencse in the same format. Do not forget to add "eula_accepted: true".
-#   {
-#     "eula_accepted": true,
-#     "company_name": "Red Hat",
-#     "contact_email": "name@redhat.com",
-#     "contact_name": "some person"
-#     "hostname": "70a415ef832159a36413fa599",
-#     "instance_count": 50,
-#     "license_date": 16581423619,
-#     "license_key":
-#     "eea1b84d1e39cfEXAMPLE5739066069e60c6d0aEXAMPLE2c29cc61b2aEXAMPLE",
-#     "license_type": "enterprise",
-#     "subscription_name": "Ansible Tower by Red Hat (50 Managed Nodes), RHT Internal",
-#     "trial": true
-#   }
+tower_license: >            #Set the tower licencse in the same format. Do not forget to add "eula_accepted: true".
+  {
+    "eula_accepted": true,
+    "company_name": "Acme Inc", 
+    "contact_email": "jsmith@example.com", 
+    "contact_name": "John Smith", 
+    "hostname": "91bbec2a58dbb802477719a01dbf6569", 
+    "instance_count": 50, 
+    "license_date": 1611432747, 
+    "license_key": "8afdf0f62334a571cf76c2dfd8c8af42f8b88085d71ad656a05dbeed04a1865a", 
+    "license_type": "enterprise", 
+    "subscription_name": "Ansible Tower by Red Hat (NN Managed Nodes), Acme Inc.", 
+    "trial": true
+  }
 
 tower_user_accounts:                                      #Define users you want to create. Set superuser: yes to make user system wide System Administrator
   - user: babylon
@@ -165,7 +169,8 @@ pip_requirements:
   - awscli==1.16.210
   - ansible-tower-cli==3.3.6
 
-
-key_local_path:
-    - "~/.ssh/{{key_name}}.pem"
-    - "~/.ssh/opentlc_admin_backdoor.pem"
+### Variables to check against in the tower_validate role, they must be aligned with what you expect
+tower_expected_instances: 4            # number of instances in the cluster, normal and isolated
+tower_expected_instance_groups: 2      # number of instance groups in the cluster
+tower_expected_licensed_min_nodes: 20  # how many managed nodes must be covered
+tower_expected_licensed_min_days: 2    # how many days there must be left on the license

--- a/ansible/configs/ansible-tower-advanced/tower_workloads.yml
+++ b/ansible/configs/ansible-tower-advanced/tower_workloads.yml
@@ -9,6 +9,7 @@
       tower_hostname: "{{ item | first }}"
     loop:
       - "{{ query('inventory_hostnames', 'towers') }}"
+    tags: must
     
   - name: Install tower-default workloads
     when:

--- a/ansible/roles/tower_validate/.travis.yml
+++ b/ansible/roles/tower_validate/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/ansible/roles/tower_validate/README.md
+++ b/ansible/roles/tower_validate/README.md
@@ -1,0 +1,42 @@
+Role Name
+=========
+
+A role to validate the setup of a Tower installation. It validates that it can ping and get
+the configuration pages with the given credentials, and, if wished, validates that the
+number of instances and instance groups is correct, as well as if the licenses has enough
+nodes and days left.
+
+Requirements
+------------
+
+Access
+
+Role Variables
+--------------
+
+All the relevant variables are listed and available in [the defaults variables](defaults/main.yml).
+
+Dependencies
+------------
+
+none.
+
+Example Playbook
+----------------
+
+Assuming that the credentials are present in your inventory, you could check the number of
+remaining license days like this:
+
+    - hosts: towers
+      roles:
+         - { role: tower_validate, tower_expected_licensed_min_days: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Eric Lavarde <elavarde@redhat.com>

--- a/ansible/roles/tower_validate/defaults/main.yml
+++ b/ansible/roles/tower_validate/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# defaults file for tower_validate
+# This file contains all variables you can influence via your inventory/variable files.
+# Commented variables have no meaningful default and the role will fail if
+# the variable isn't defined somewhere (inventory or variable file).
+
+# The name of the Tower to address
+#tower_hostname: tower.GUID.sandboxSBUID.example.com
+# The user name of the Tower admin
+tower_admin_user: admin
+# The password of the Tower admin
+#tower_admin_password: changeme
+# Validate or not the Tower certificate (the default of false isn't recommended practice but usual)
+tower_validate_certs: false
+
+# the following variables, if defined, are checked against the current values known to Tower
+#tower_expected_instances: 4            # number of instances in the cluster, normal and isolated
+#tower_expected_instance_groups: 2      # number of instance groups in the cluster
+#tower_expected_licensed_min_nodes: 50  # how many managed nodes must be covered
+#tower_expected_licensed_min_days: 1    # how many days there must be left on the license

--- a/ansible/roles/tower_validate/meta/main.yml
+++ b/ansible/roles/tower_validate/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: Eric Lavarde <elavarde@redhat.com>
+  description: Principal Architect, Red Hat Consulting
+  company: Red Hat
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: BSD
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/ansible/roles/tower_validate/tasks/main.yml
+++ b/ansible/roles/tower_validate/tasks/main.yml
@@ -1,0 +1,57 @@
+---
+# tasks file for tower_validate
+- name: ping the Tower using the API
+  uri:
+    url: "https://{{ tower_hostname }}/api/v2/ping/"
+    validate_certs: "{{ tower_validate_certs }}"
+    method: GET
+    headers:
+      #Content-Type: "application/json"
+      Authorization: "Basic {{ (tower_admin_user + ':' + tower_admin_password) | b64encode }}"
+  register: tower_ping_res
+- name: output the Tower ping result
+  debug:
+    var: tower_ping_res
+    verbosity: 2  # only outputs when -vv or more
+- name: gather the Tower configuration using the API
+  uri:
+    url: "https://{{ tower_hostname }}/api/v2/config/"
+    validate_certs: "{{ tower_validate_certs }}"
+    method: GET
+    headers:
+      #Content-Type: "application/json"
+      Authorization: "Basic {{ (tower_admin_user + ':' + tower_admin_password) | b64encode }}"
+  register: tower_config_res
+- name: output the Tower configuration result
+  debug:
+    var: tower_config_res
+    verbosity: 2  # only outputs when -vv or more
+
+# Validate the expected values of Tower are met by the current installation
+
+# NOTE: the `| int` are required to also allow to overwrite the variables on the command line
+
+- name: validate that Tower cluster has the right number of instances
+  assert:
+    that:
+    - tower_ping_res.json.instances | length == tower_expected_instances | int
+    fail_msg: "tower_ping_res.json.instances {{ tower_ping_res.json.instances | length }} != tower_expected_instances {{ tower_expected_instances }}"
+  when: tower_expected_instances is defined
+- name: validate that Tower cluster has the right number of instance groups
+  assert:
+    that:
+    - tower_ping_res.json.instance_groups | length == tower_expected_instance_groups | int
+    fail_msg: "tower_ping_res.json.instance_groups {{ tower_ping_res.json.instance_groups | length }} != tower_expected_instance_groups {{ tower_expected_instance_groups }}"
+  when: tower_expected_instance_groups is defined
+- name: validate that Tower cluster has enough nodes licensed
+  assert:
+    that:
+    - tower_config_res.json.license_info.available_instances >= tower_expected_licensed_min_nodes | int
+    fail_msg: "tower_config_res.json.license_info.available_instances {{ tower_config_res.json.license_info.available_instances }} is less than tower_expected_licensed_min_nodes {{ tower_expected_licensed_min_nodes }}"
+  when: tower_expected_licensed_min_nodes is defined
+- name: validate that Tower cluster has enough time left
+  assert:
+    that:
+    - tower_config_res.json.license_info.time_remaining >= (tower_expected_licensed_min_days | int * 24 * 3600)
+    fail_msg: "tower_config_res.json.license_info.time_remaining {{ tower_config_res.json.license_info.time_remaining }} (in secs) is less than tower_expected_licensed_min_days {{ tower_expected_licensed_min_days }} (in days)"
+  when: tower_expected_licensed_min_days is defined


### PR DESCRIPTION
As the subject says:
- compared to the base branch create-ansible-tower-advanced-for summit-2020, there is a new role tower_validate, called from post_software.yml
- the sample_vars.yml has been aligned with my personal vars file (previously uploaded to GDrive), and extended with the necessary variables to validate the Tower installation
- the README.adoc has been re-written to better fit the current status of the implementation.

If you agree, I would suggest to merge the whole branch with upstream agnosticd once someone else from the team has tested the change, and the PR has been merged.